### PR TITLE
Install ldap_user, ldap_authentication by default

### DIFF
--- a/identity_provider.info.yml
+++ b/identity_provider.info.yml
@@ -95,6 +95,8 @@ install:
   - key
   - ldap
   - ldap_servers
+  - ldap_authentication
+  - ldap_user
   - login_security
   - mail_login
   - openapi


### PR DESCRIPTION
The configuration are already imported but not the required modules. The existing configuration prevents the installation of the modules.